### PR TITLE
API-7258: headers named 'server' and 'x-envoy-upstream-service-time' …

### DIFF
--- a/app/uk/gov/hmrc/apiplatforminboundsoap/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/apiplatforminboundsoap/config/AppConfig.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.apiplatforminboundsoap.config
 
 import javax.inject.{Inject, Singleton}
+
 import play.api.Configuration
 
 @Singleton

--- a/app/uk/gov/hmrc/apiplatforminboundsoap/config/JWTVerifierProvider.scala
+++ b/app/uk/gov/hmrc/apiplatforminboundsoap/config/JWTVerifierProvider.scala
@@ -16,8 +16,10 @@
 
 package uk.gov.hmrc.apiplatforminboundsoap.config
 
-import com.auth0.jwt.interfaces.JWTVerifier
 import javax.inject.{Inject, Provider, Singleton}
+
+import com.auth0.jwt.interfaces.JWTVerifier
+
 import uk.gov.hmrc.apiplatforminboundsoap.jwt.JWTVerifierBuilder
 
 @Singleton

--- a/app/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnector.scala
+++ b/app/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnector.scala
@@ -17,27 +17,24 @@
 package uk.gov.hmrc.apiplatforminboundsoap.connectors
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.control.NonFatal
-
 import play.api.Logging
 import play.api.http.Status
+import play.api.mvc.Headers
 import uk.gov.hmrc.apiplatforminboundsoap.models.{SendFail, SendResult, SendSuccess, SoapRequest}
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorResponse}
 
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+
 @Singleton
 class InboundConnector @Inject() (httpClient: HttpClient)(implicit ec: ExecutionContext) extends Logging {
 
-  def postMessage(soapRequest: SoapRequest): Future[SendResult] = {
+  def postMessage(soapRequest: SoapRequest, headers: Headers): Future[SendResult] = {
     implicit val hc: HeaderCarrier                                                                                                 = HeaderCarrier()
-      .withExtraHeaders(
-        "x-soap-action"    -> "action from message",
-        "x-correlation-id" -> "x-correlation-id-value",
-        "x-message-id"     -> "x-message-id-value"
-      )
+
     def postHttpRequest(soapRequest: SoapRequest)(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, HttpResponse]] = {
-      httpClient.POSTString[Either[UpstreamErrorResponse, HttpResponse]](soapRequest.destinationUrl, soapRequest.soapEnvelope)
+      httpClient.POSTString[Either[UpstreamErrorResponse, HttpResponse]](soapRequest.destinationUrl, soapRequest.soapEnvelope, headers.headers)
     }
 
     postHttpRequest(soapRequest).map {

--- a/app/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnector.scala
+++ b/app/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnector.scala
@@ -17,6 +17,9 @@
 package uk.gov.hmrc.apiplatforminboundsoap.connectors
 
 import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+
 import play.api.Logging
 import play.api.http.Status
 import play.api.mvc.Headers
@@ -24,14 +27,11 @@ import uk.gov.hmrc.apiplatforminboundsoap.models.{SendFail, SendResult, SendSucc
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorResponse}
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.control.NonFatal
-
 @Singleton
 class InboundConnector @Inject() (httpClient: HttpClient)(implicit ec: ExecutionContext) extends Logging {
 
   def postMessage(soapRequest: SoapRequest, headers: Headers): Future[SendResult] = {
-    implicit val hc: HeaderCarrier                                                                                                 = HeaderCarrier()
+    implicit val hc: HeaderCarrier = HeaderCarrier()
 
     def postHttpRequest(soapRequest: SoapRequest)(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, HttpResponse]] = {
       httpClient.POSTString[Either[UpstreamErrorResponse, HttpResponse]](soapRequest.destinationUrl, soapRequest.soapEnvelope, headers.headers)

--- a/app/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnector.scala
+++ b/app/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnector.scala
@@ -30,10 +30,9 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorR
 @Singleton
 class InboundConnector @Inject() (httpClient: HttpClient)(implicit ec: ExecutionContext) extends Logging {
 
-  def postMessage(soapRequest: SoapRequest, headers: Headers): Future[SendResult] = {
-    implicit val hc: HeaderCarrier = HeaderCarrier()
+  def postMessage(soapRequest: SoapRequest, headers: Headers)(implicit hc:HeaderCarrier): Future[SendResult] = {
 
-    def postHttpRequest(soapRequest: SoapRequest)(implicit hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, HttpResponse]] = {
+    def postHttpRequest(soapRequest: SoapRequest): Future[Either[UpstreamErrorResponse, HttpResponse]] = {
       httpClient.POSTString[Either[UpstreamErrorResponse, HttpResponse]](soapRequest.destinationUrl, soapRequest.soapEnvelope, headers.headers)
     }
 

--- a/app/uk/gov/hmrc/apiplatforminboundsoap/controllers/CCN2MessageController.scala
+++ b/app/uk/gov/hmrc/apiplatforminboundsoap/controllers/CCN2MessageController.scala
@@ -17,11 +17,10 @@
 package uk.gov.hmrc.apiplatforminboundsoap.controllers
 
 import javax.inject.{Inject, Singleton}
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.NodeSeq
-
-import play.api.Logging
-import play.api.mvc.{Action, ControllerComponents}
+import play.api.mvc.{Action, ControllerComponents, Request}
 import uk.gov.hmrc.apiplatforminboundsoap.models.{SendFail, SendSuccess}
 import uk.gov.hmrc.apiplatforminboundsoap.services.InboundMessageService
 import uk.gov.hmrc.apiplatformoutboundsoap.controllers.actionBuilders.VerifyJwtTokenAction
@@ -36,7 +35,7 @@ class CCN2MessageController @Inject() (
   ) extends BackendController(cc) {
 
   def message(path: String): Action[NodeSeq] = (Action andThen verifyJwtTokenAction).async(parse.xml) { implicit request =>
-    incomingMessageService.processInboundMessage(request.body) flatMap {
+    incomingMessageService.processInboundMessage(request.body, request.headers) flatMap {
       case SendSuccess      =>
         Future.successful(Ok)
       case SendFail(status) =>

--- a/app/uk/gov/hmrc/apiplatforminboundsoap/controllers/CCN2MessageController.scala
+++ b/app/uk/gov/hmrc/apiplatforminboundsoap/controllers/CCN2MessageController.scala
@@ -17,10 +17,10 @@
 package uk.gov.hmrc.apiplatforminboundsoap.controllers
 
 import javax.inject.{Inject, Singleton}
-
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.NodeSeq
-import play.api.mvc.{Action, ControllerComponents, Request}
+
+import play.api.mvc.{Action, ControllerComponents}
 import uk.gov.hmrc.apiplatforminboundsoap.models.{SendFail, SendSuccess}
 import uk.gov.hmrc.apiplatforminboundsoap.services.InboundMessageService
 import uk.gov.hmrc.apiplatformoutboundsoap.controllers.actionBuilders.VerifyJwtTokenAction

--- a/app/uk/gov/hmrc/apiplatforminboundsoap/jwt/JWTVerifierBuilder.scala
+++ b/app/uk/gov/hmrc/apiplatforminboundsoap/jwt/JWTVerifierBuilder.scala
@@ -16,10 +16,12 @@
 
 package uk.gov.hmrc.apiplatforminboundsoap.jwt
 
+import javax.inject.{Inject, Singleton}
+
 import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.interfaces.JWTVerifier
 import com.auth0.jwt.{JWT, RegisteredClaims}
-import javax.inject.{Inject, Singleton}
+
 import uk.gov.hmrc.apiplatforminboundsoap.config.AppConfig
 
 @Singleton

--- a/app/uk/gov/hmrc/apiplatforminboundsoap/services/InboundMessageService.scala
+++ b/app/uk/gov/hmrc/apiplatforminboundsoap/services/InboundMessageService.scala
@@ -17,26 +17,24 @@
 package uk.gov.hmrc.apiplatforminboundsoap.services
 
 import javax.inject.{Inject, Singleton}
+import scala.concurrent.Future
+import scala.xml.NodeSeq
+
 import play.api.Logging
-import play.api.mvc.{Headers, Request}
+import play.api.mvc.Headers
 import uk.gov.hmrc.apiplatforminboundsoap.config.AppConfig
 import uk.gov.hmrc.apiplatforminboundsoap.connectors.InboundConnector
 import uk.gov.hmrc.apiplatforminboundsoap.models.{SendResult, SoapRequest}
 import uk.gov.hmrc.http.HeaderCarrier
 
-import scala.concurrent.Future
-import scala.xml.NodeSeq
-
 @Singleton
 class InboundMessageService @Inject() (appConfig: AppConfig, inboundConnector: InboundConnector) extends Logging {
 
   def processInboundMessage(soapRequest: NodeSeq, headers: Headers)(implicit hc: HeaderCarrier): Future[SendResult] = {
-    val existingHeaders = headers
+    val existingHeaders     = headers
     val newHeaders: Headers = existingHeaders
       .remove("server", "x-envoy-upstream-service-time")
-      .add("x-soap-action"-> "action from message",
-      "x-correlation-id" -> "x-correlation-id-value",
-      "x-message-id"  -> "x-message-id-value")
+      .add("x-soap-action" -> "action from message", "x-correlation-id" -> "x-correlation-id-value", "x-message-id" -> "x-message-id-value")
     inboundConnector.postMessage(SoapRequest(soapRequest.text, appConfig.forwardMessageUrl), newHeaders)
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -52,7 +52,7 @@ play.http.router = prod.Routes
 # auditing (transaction monitoring) enabled.
 # The below controllers are the default exceptions to this rule.
 
-forwardMessageUrl = "http://localhost:9865"
+forwardMessageUrl = "http://localhost:6704"
 
 # JWT token validation
 hmacSecret = "a very long secret which must be more than two hundred and fifty six bits long"

--- a/it/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnectorISpec.scala
+++ b/it/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnectorISpec.scala
@@ -26,10 +26,12 @@ import play.api.mvc.Headers
 import play.api.test.Helpers._
 import uk.gov.hmrc.apiplatforminboundsoap.models.{SendFail, SendResult, SendSuccess, SoapRequest}
 import uk.gov.hmrc.apiplatforminboundsoap.support.ImportControlInboundSoapStub
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.test.WireMockSupport
 
 class InboundConnectorISpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with WireMockSupport with ImportControlInboundSoapStub {
   override implicit lazy val app: Application = appBuilder.build()
+  implicit val hc: HeaderCarrier = HeaderCarrier()
 
   protected def appBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()

--- a/it/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnectorISpec.scala
+++ b/it/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnectorISpec.scala
@@ -39,7 +39,7 @@ class InboundConnectorISpec extends AnyWordSpec with Matchers with GuiceOneAppPe
       )
 
   trait Setup {
-    val headers = Headers("key" -> "value")
+    val headers                     = Headers("key" -> "value")
     val underTest: InboundConnector = app.injector.instanceOf[InboundConnector]
   }
 
@@ -50,7 +50,7 @@ class InboundConnectorISpec extends AnyWordSpec with Matchers with GuiceOneAppPe
       val expectedStatus: Int = OK
       primeStubForSuccess(message.soapEnvelope, expectedStatus)
 
-      val result: SendResult = await(underTest.postMessage(message,headers))
+      val result: SendResult = await(underTest.postMessage(message, headers))
 
       result shouldBe SendSuccess
     }
@@ -59,7 +59,7 @@ class InboundConnectorISpec extends AnyWordSpec with Matchers with GuiceOneAppPe
       val expectedStatus: Int = INTERNAL_SERVER_ERROR
       primeStubForSuccess(message.soapEnvelope, expectedStatus)
 
-      val result: SendResult = await(underTest.postMessage(message,headers))
+      val result: SendResult = await(underTest.postMessage(message, headers))
 
       result shouldBe SendFail(expectedStatus)
     }
@@ -68,7 +68,7 @@ class InboundConnectorISpec extends AnyWordSpec with Matchers with GuiceOneAppPe
       Seq(Fault.CONNECTION_RESET_BY_PEER, Fault.EMPTY_RESPONSE, Fault.MALFORMED_RESPONSE_CHUNK, Fault.RANDOM_DATA_THEN_CLOSE) foreach { fault =>
         primeStubForFault(message.soapEnvelope, fault)
 
-        val result: SendResult = await(underTest.postMessage(message,headers))
+        val result: SendResult = await(underTest.postMessage(message, headers))
 
         result shouldBe SendFail(INTERNAL_SERVER_ERROR)
       }
@@ -77,7 +77,7 @@ class InboundConnectorISpec extends AnyWordSpec with Matchers with GuiceOneAppPe
     "send the given message to the internal service" in new Setup {
       primeStubForSuccess(message.soapEnvelope, OK)
 
-      await(underTest.postMessage(message,headers))
+      await(underTest.postMessage(message, headers))
 
       verifyRequestBody(message.soapEnvelope)
     }

--- a/it/uk/gov/hmrc/apiplatforminboundsoap/support/ImportControlInboundSoapStub.scala
+++ b/it/uk/gov/hmrc/apiplatforminboundsoap/support/ImportControlInboundSoapStub.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.apiplatforminboundsoap.support
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.http.Fault
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 
 trait ImportControlInboundSoapStub {
@@ -45,7 +46,11 @@ trait ImportControlInboundSoapStub {
       .withRequestBody(equalTo(expectedRequestBody)))
   }
 
-  def verifyHeader(headerName: String, headerValue: String): Unit = {
+  def verifyHeaderPresent(headerName: String, headerValue: String): Unit = {
     verify(postRequestedFor(urlPathEqualTo("/")).withHeader(headerName, equalTo(headerValue)))
+  }
+
+  def verifyHeaderAbsent(headerName: String*): Unit = {
+    headerName.foreach(nm => verify(postRequestedFor(urlPathEqualTo("/")).withoutHeader(nm)))
   }
 }

--- a/it/uk/gov/hmrc/apiplatforminboundsoap/support/ImportControlInboundSoapStub.scala
+++ b/it/uk/gov/hmrc/apiplatforminboundsoap/support/ImportControlInboundSoapStub.scala
@@ -46,11 +46,7 @@ trait ImportControlInboundSoapStub {
       .withRequestBody(equalTo(expectedRequestBody)))
   }
 
-  def verifyHeaderPresent(headerName: String, headerValue: String): Unit = {
+  def verifyHeader(headerName: String, headerValue: String): Unit = {
     verify(postRequestedFor(urlPathEqualTo("/")).withHeader(headerName, equalTo(headerValue)))
-  }
-
-  def verifyHeaderAbsent(headerName: String*): Unit = {
-    headerName.foreach(nm => verify(postRequestedFor(urlPathEqualTo("/")).withoutHeader(nm)))
   }
 }

--- a/it/uk/gov/hmrc/apiplatforminboundsoap/support/ImportControlInboundSoapStub.scala
+++ b/it/uk/gov/hmrc/apiplatforminboundsoap/support/ImportControlInboundSoapStub.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.apiplatforminboundsoap.support
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.http.Fault
-import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 
 trait ImportControlInboundSoapStub {

--- a/run_local_with_dependencies.sh
+++ b/run_local_with_dependencies.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sm --start DATASTREAM API_PLATFORM_TEST API_PLATFORM_OUTBOUND_SOAP
+
+sbt run

--- a/test/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnectorSpec.scala
+++ b/test/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnectorSpec.scala
@@ -18,10 +18,12 @@ package uk.gov.hmrc.apiplatforminboundsoap.connectors
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future.{failed, successful}
+
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+
 import play.api.Application
 import play.api.http.Status.OK
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -40,7 +42,7 @@ class InboundConnectorSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
 
   trait Setup {
     val appConfigMock: AppConfig   = mock[AppConfig]
-    val headers = Headers("key" -> "value")
+    val headers                    = Headers("key" -> "value")
     val mockHttpClient: HttpClient = mock[HttpClient]
     val underTest                  = new InboundConnector(mockHttpClient)
   }

--- a/test/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnectorSpec.scala
+++ b/test/uk/gov/hmrc/apiplatforminboundsoap/connectors/InboundConnectorSpec.scala
@@ -18,15 +18,14 @@ package uk.gov.hmrc.apiplatforminboundsoap.connectors
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future.{failed, successful}
-
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-
 import play.api.Application
 import play.api.http.Status.OK
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.Headers
 import play.api.test.Helpers.{INTERNAL_SERVER_ERROR, await, defaultAwaitTimeout}
 import uk.gov.hmrc.apiplatforminboundsoap.config.AppConfig
 import uk.gov.hmrc.apiplatforminboundsoap.models.{SendFail, SendResult, SendSuccess, SoapRequest}
@@ -41,6 +40,7 @@ class InboundConnectorSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
 
   trait Setup {
     val appConfigMock: AppConfig   = mock[AppConfig]
+    val headers = Headers("key" -> "value")
     val mockHttpClient: HttpClient = mock[HttpClient]
     val underTest                  = new InboundConnector(mockHttpClient)
   }
@@ -50,7 +50,7 @@ class InboundConnectorSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
       val soapRequest: SoapRequest = SoapRequest("<xml>stuff</xml>", "some url")
       when(mockHttpClient.POSTString[Either[UpstreamErrorResponse, HttpResponse]](*, *, *)(*, *, *))
         .thenReturn(successful(Right(HttpResponse(OK, ""))))
-      val result: SendResult       = await(underTest.postMessage(soapRequest))
+      val result: SendResult       = await(underTest.postMessage(soapRequest, headers))
       result shouldBe SendSuccess
     }
 
@@ -58,7 +58,7 @@ class InboundConnectorSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
       val soapRequest: SoapRequest = SoapRequest("<xml>stuff</xml>", "some url")
       when(mockHttpClient.POSTString[Either[UpstreamErrorResponse, HttpResponse]](*, *, *)(*, *, *))
         .thenReturn(successful(Left(UpstreamErrorResponse("unexpected error", INTERNAL_SERVER_ERROR))))
-      val result: SendResult       = await(underTest.postMessage(soapRequest))
+      val result: SendResult       = await(underTest.postMessage(soapRequest, headers))
       result shouldBe SendFail(INTERNAL_SERVER_ERROR)
     }
 
@@ -67,7 +67,7 @@ class InboundConnectorSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
 
       when(mockHttpClient.POSTString[Either[UpstreamErrorResponse, HttpResponse]](*, *, *)(*, *, *))
         .thenReturn(failed(play.shaded.ahc.org.asynchttpclient.exception.RemotelyClosedException.INSTANCE))
-      val result: SendResult = await(underTest.postMessage(soapRequest))
+      val result: SendResult = await(underTest.postMessage(soapRequest, headers))
       result shouldBe SendFail(INTERNAL_SERVER_ERROR)
     }
   }

--- a/test/uk/gov/hmrc/apiplatforminboundsoap/controllers/CCN2MessageControllerSpec.scala
+++ b/test/uk/gov/hmrc/apiplatforminboundsoap/controllers/CCN2MessageControllerSpec.scala
@@ -19,11 +19,13 @@ package uk.gov.hmrc.apiplatforminboundsoap.controllers
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future.successful
 import scala.xml.{Elem, XML}
+
 import org.mockito.captor.{ArgCaptor, Captor}
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+
 import play.api.mvc.Headers
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Helpers}
@@ -36,10 +38,12 @@ class CCN2MessageControllerSpec extends AnyWordSpec with Matchers with GuiceOneA
   trait Setup {
     private val verifyJwtTokenAction = app.injector.instanceOf[VerifyJwtTokenAction]
     val incomingMessageServiceMock   = mock[InboundMessageService]
+
     val headers                      = Headers(
-      "Host"-> "localhost",
+      "Host"          -> "localhost",
       "Authorization" -> "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIwMDc5NzcwNzd9.bgdyMvTvicf5FvAlQXN-311k0WTZg0-72wqR4hb66dQ",
-      "Content-Type" -> "text/xml")
+      "Content-Type"  -> "text/xml"
+    )
     val controller                   = new CCN2MessageController(Helpers.stubControllerComponents(), verifyJwtTokenAction, incomingMessageServiceMock)
   }
 
@@ -49,29 +53,29 @@ class CCN2MessageControllerSpec extends AnyWordSpec with Matchers with GuiceOneA
       .withHeaders("Content-Type" -> "text/xml")
 
     "return 200 when successful" in new Setup {
-      val xmlRequestCaptor: Captor[Elem] = ArgCaptor[Elem]
+      val xmlRequestCaptor: Captor[Elem]       = ArgCaptor[Elem]
       val requestHeaderCaptor: Captor[Headers] = ArgCaptor[Headers]
-      val requestBody: Elem              = XML.loadString("<xml>blah</xml>")
+      val requestBody: Elem                    = XML.loadString("<xml>blah</xml>")
       when(incomingMessageServiceMock.processInboundMessage(xmlRequestCaptor, requestHeaderCaptor)(*)).thenReturn(successful(SendSuccess))
 
       val result = controller.message("NESControlBASV2")(fakeRequest.withBody(requestBody))
 
       status(result) shouldBe OK
-      verify(incomingMessageServiceMock).processInboundMessage(*,*)(*)
+      verify(incomingMessageServiceMock).processInboundMessage(*, *)(*)
       xmlRequestCaptor hasCaptured requestBody
       requestHeaderCaptor hasCaptured headers
     }
 
     "return response code it received when not successful" in new Setup {
-      val xmlRequestCaptor: Captor[Elem] = ArgCaptor[Elem]
+      val xmlRequestCaptor: Captor[Elem]       = ArgCaptor[Elem]
       val requestHeaderCaptor: Captor[Headers] = ArgCaptor[Headers]
-      val requestBody: Elem              = XML.loadString("<xml>blah</xml>")
+      val requestBody: Elem                    = XML.loadString("<xml>blah</xml>")
       when(incomingMessageServiceMock.processInboundMessage(xmlRequestCaptor, requestHeaderCaptor)(*)).thenReturn(successful(SendFail(PRECONDITION_FAILED)))
 
       val result = controller.message("NESControlBASV2")(fakeRequest.withBody(requestBody))
 
       status(result) shouldBe PRECONDITION_FAILED
-      verify(incomingMessageServiceMock).processInboundMessage(*,*)(*)
+      verify(incomingMessageServiceMock).processInboundMessage(*, *)(*)
       xmlRequestCaptor hasCaptured requestBody
       requestHeaderCaptor hasCaptured headers
     }

--- a/test/uk/gov/hmrc/apiplatforminboundsoap/controllers/CCN2MessageControllerSpec.scala
+++ b/test/uk/gov/hmrc/apiplatforminboundsoap/controllers/CCN2MessageControllerSpec.scala
@@ -19,13 +19,12 @@ package uk.gov.hmrc.apiplatforminboundsoap.controllers
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future.successful
 import scala.xml.{Elem, XML}
-
 import org.mockito.captor.{ArgCaptor, Captor}
 import org.mockito.{ArgumentMatchersSugar, MockitoSugar}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-
+import play.api.mvc.Headers
 import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Helpers}
 import uk.gov.hmrc.apiplatforminboundsoap.models.{SendFail, SendSuccess}
@@ -37,6 +36,10 @@ class CCN2MessageControllerSpec extends AnyWordSpec with Matchers with GuiceOneA
   trait Setup {
     private val verifyJwtTokenAction = app.injector.instanceOf[VerifyJwtTokenAction]
     val incomingMessageServiceMock   = mock[InboundMessageService]
+    val headers                      = Headers(
+      "Host"-> "localhost",
+      "Authorization" -> "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIwMDc5NzcwNzd9.bgdyMvTvicf5FvAlQXN-311k0WTZg0-72wqR4hb66dQ",
+      "Content-Type" -> "text/xml")
     val controller                   = new CCN2MessageController(Helpers.stubControllerComponents(), verifyJwtTokenAction, incomingMessageServiceMock)
   }
 
@@ -47,27 +50,30 @@ class CCN2MessageControllerSpec extends AnyWordSpec with Matchers with GuiceOneA
 
     "return 200 when successful" in new Setup {
       val xmlRequestCaptor: Captor[Elem] = ArgCaptor[Elem]
+      val requestHeaderCaptor: Captor[Headers] = ArgCaptor[Headers]
       val requestBody: Elem              = XML.loadString("<xml>blah</xml>")
-      when(incomingMessageServiceMock.processInboundMessage(xmlRequestCaptor)(*)).thenReturn(successful(SendSuccess))
+      when(incomingMessageServiceMock.processInboundMessage(xmlRequestCaptor, requestHeaderCaptor)(*)).thenReturn(successful(SendSuccess))
 
       val result = controller.message("NESControlBASV2")(fakeRequest.withBody(requestBody))
 
       status(result) shouldBe OK
-      verify(incomingMessageServiceMock).processInboundMessage(*)(*)
+      verify(incomingMessageServiceMock).processInboundMessage(*,*)(*)
       xmlRequestCaptor hasCaptured requestBody
+      requestHeaderCaptor hasCaptured headers
     }
 
     "return response code it received when not successful" in new Setup {
       val xmlRequestCaptor: Captor[Elem] = ArgCaptor[Elem]
+      val requestHeaderCaptor: Captor[Headers] = ArgCaptor[Headers]
       val requestBody: Elem              = XML.loadString("<xml>blah</xml>")
-      when(incomingMessageServiceMock.processInboundMessage(xmlRequestCaptor)(*)).thenReturn(successful(SendFail(PRECONDITION_FAILED)))
+      when(incomingMessageServiceMock.processInboundMessage(xmlRequestCaptor, requestHeaderCaptor)(*)).thenReturn(successful(SendFail(PRECONDITION_FAILED)))
 
       val result = controller.message("NESControlBASV2")(fakeRequest.withBody(requestBody))
 
       status(result) shouldBe PRECONDITION_FAILED
-      verify(incomingMessageServiceMock).processInboundMessage(*)(*)
+      verify(incomingMessageServiceMock).processInboundMessage(*,*)(*)
       xmlRequestCaptor hasCaptured requestBody
+      requestHeaderCaptor hasCaptured headers
     }
   }
-
 }

--- a/test/uk/gov/hmrc/apiplatforminboundsoap/services/InboundMessageServiceSpec.scala
+++ b/test/uk/gov/hmrc/apiplatforminboundsoap/services/InboundMessageServiceSpec.scala
@@ -70,7 +70,8 @@ class InboundMessageServiceSpec extends AnyWordSpec with Matchers with GuiceOneA
     "return success when connector returns success" in new Setup {
       val bodyCaptor   = ArgCaptor[SoapRequest]
       val headerCaptor = ArgCaptor[Headers]
-      when(inboundConnectorMock.postMessage(bodyCaptor, headerCaptor)).thenReturn(successful(SendSuccess))
+      val hcCaptor = ArgCaptor[HeaderCarrier]
+      when(inboundConnectorMock.postMessage(bodyCaptor, headerCaptor)(hcCaptor)).thenReturn(successful(SendSuccess))
       when(appConfigMock.forwardMessageUrl).thenReturn(forwardingUrl)
 
       val result = await(service.processInboundMessage(xmlBody, requestHeaders))
@@ -85,7 +86,8 @@ class InboundMessageServiceSpec extends AnyWordSpec with Matchers with GuiceOneA
     "return failure when connector returns failure" in new Setup {
       val bodyCaptor   = ArgCaptor[SoapRequest]
       val headerCaptor = ArgCaptor[Headers]
-      when(inboundConnectorMock.postMessage(bodyCaptor, headerCaptor)).thenReturn(successful(SendFail(IM_A_TEAPOT)))
+      val hcCaptor = ArgCaptor[HeaderCarrier]
+      when(inboundConnectorMock.postMessage(bodyCaptor, headerCaptor)(hcCaptor)).thenReturn(successful(SendFail(IM_A_TEAPOT)))
       when(appConfigMock.forwardMessageUrl).thenReturn(forwardingUrl)
 
       val result = await(service.processInboundMessage(xmlBody, requestHeaders))


### PR DESCRIPTION
…are removed from requests before they are forwarded