### PR TITLE
API-8492: add slash before CRDL path in the connector

### DIFF
--- a/app/uk/gov/hmrc/apiplatforminboundsoap/config/ConfigurationProviders.scala
+++ b/app/uk/gov/hmrc/apiplatforminboundsoap/config/ConfigurationProviders.scala
@@ -56,7 +56,7 @@ class CrdlOrchestratorConnectorConfigProvider @Inject() (val configuration: Conf
 
   override def get(): CrdlOrchestratorConnector.Config = {
     val url  = baseUrl("crdl-orchestrator")
-    val path = getConfString("crdl-orchestrator.path", "/crdl/incoming")
+    val path = getConfString("crdl-orchestrator.path", "crdl/incoming")
     CrdlOrchestratorConnector.Config(url, path)
   }
 }

--- a/app/uk/gov/hmrc/apiplatforminboundsoap/connectors/CrdlOrchestratorConnector.scala
+++ b/app/uk/gov/hmrc/apiplatforminboundsoap/connectors/CrdlOrchestratorConnector.scala
@@ -37,7 +37,7 @@ class CrdlOrchestratorConnector @Inject() (httpClientV2: HttpClientV2, appConfig
     extends BaseConnector(httpClientV2) with ApplicationLogger {
 
   def postMessage(soapRequest: NodeSeq, headers: Seq[(String, String)])(implicit hc: HeaderCarrier): Future[SendResult] = {
-    postHttpRequest(soapRequest, headers, s"${appConfig.baseUrl}${appConfig.path}").map {
+    postHttpRequest(soapRequest, headers, s"${appConfig.baseUrl}/${appConfig.path}").map {
 
       case Right(response)                                        => SendSuccess(response.status)
       case Left(UpstreamErrorResponse(message, statusCode, _, _)) =>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -71,7 +71,7 @@ microservice {
     }
     crdl-orchestrator {
       host = localhost
-      port = 3000
+      port = 7250
       path = "crdl/incoming"
 
     }
@@ -81,7 +81,7 @@ microservice {
     }
     secure-data-exchange-proxy {
       host = localhost
-      port = 3000
+      port = 6704
       uploadPath = upload-attachment
       ics2.srn = "SRN1234"
       ics2.informationType = "infotype12345v2"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -71,8 +71,8 @@ microservice {
     }
     crdl-orchestrator {
       host = localhost
-      port = 7250
-      path = "/crdl/incoming"
+      port = 3000
+      path = "crdl/incoming"
 
     }
     import-control-inbound-soap {
@@ -81,7 +81,7 @@ microservice {
     }
     secure-data-exchange-proxy {
       host = localhost
-      port = 6704
+      port = 3000
       uploadPath = upload-attachment
       ics2.srn = "SRN1234"
       ics2.informationType = "infotype12345v2"

--- a/it/test/uk/gov/hmrc/apiplatforminboundsoap/connectors/CrdlOrchestratorConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/apiplatforminboundsoap/connectors/CrdlOrchestratorConnectorISpec.scala
@@ -39,7 +39,7 @@ class CrdlOrchestratorConnectorISpec extends AnyWordSpec with Matchers with Guic
     with ExternalWireMockSupport with ApiPlatformOutboundSoapStub with Ics2XmlHelper {
   override implicit lazy val app: Application = appBuilder.build()
   implicit val hc: HeaderCarrier              = HeaderCarrier()
-  val targetPath                              = "/crdl/incoming"
+  val configTargetPath                        = "crdl/incoming"
 
   protected def appBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()
@@ -48,13 +48,14 @@ class CrdlOrchestratorConnectorISpec extends AnyWordSpec with Matchers with Guic
         "auditing.enabled"                             -> false,
         "microservice.services.crdl-orchestrator.host" -> externalWireMockHost,
         "microservice.services.crdl-orchestrator.port" -> externalWireMockPort,
-        "microservice.services.crdl-orchestrator.path" -> targetPath
+        "microservice.services.crdl-orchestrator.path" -> configTargetPath
       )
 
   trait Setup {
     val underTest: CrdlOrchestratorConnector = app.injector.instanceOf[CrdlOrchestratorConnector]
     val crdlRequestBody: Elem                = readFromFile("requests/crdl/crdl-request.xml")
     val addedHeaders                         = Seq.empty
+    val wireMockTargetPath                   = s"/$configTargetPath"
 
     def readFromFile(fileName: String) = {
       XML.load(Source.fromResource(fileName).bufferedReader())
@@ -64,21 +65,21 @@ class CrdlOrchestratorConnectorISpec extends AnyWordSpec with Matchers with Guic
   "postMessage" should {
 
     "return success status when returned by the CRDL orchestrator service" in new Setup {
-      primeStubForSuccess(crdlRequestBody, OK, path = targetPath)
+      primeStubForSuccess(crdlRequestBody, OK, path = wireMockTargetPath)
 
       val result: SendResult = await(underTest.postMessage(crdlRequestBody, addedHeaders))
 
       result shouldBe SendSuccess(OK)
-      verifyRequestBody(crdlRequestBody, path = targetPath)
+      verifyRequestBody(crdlRequestBody, path = wireMockTargetPath)
     }
 
     "return error status returned by the CRDL orchestrator service" in new Setup {
       val expectedStatus: Int = INTERNAL_SERVER_ERROR
-      primeStubForSuccess(crdlRequestBody, expectedStatus, path = targetPath)
+      primeStubForSuccess(crdlRequestBody, expectedStatus, path = wireMockTargetPath)
 
       val result: SendResult = await(underTest.postMessage(crdlRequestBody, addedHeaders))
 
-      result shouldBe SendFailExternal(s"POST of 'http://$externalWireMockHost:$externalWireMockPort$targetPath' returned $expectedStatus. Response body: ''", expectedStatus)
+      result shouldBe SendFailExternal(s"POST of 'http://$externalWireMockHost:$externalWireMockPort/$configTargetPath' returned $expectedStatus. Response body: ''", expectedStatus)
     }
 
     "return error status when soap fault is returned by the internal service" in new Setup {
@@ -89,7 +90,7 @@ class CrdlOrchestratorConnectorISpec extends AnyWordSpec with Matchers with Guic
         Fault.MALFORMED_RESPONSE_CHUNK -> "Remotely closed",
         Fault.RANDOM_DATA_THEN_CLOSE   -> "Remotely closed"
       ) foreach { input =>
-        primeStubForFault(crdlRequestBody, responseBody, input._1, targetPath)
+        primeStubForFault(crdlRequestBody, responseBody, input._1, wireMockTargetPath)
 
         val result: SendResult = await(underTest.postMessage(crdlRequestBody, addedHeaders))
 


### PR DESCRIPTION
 instead of in config